### PR TITLE
fix: add PyYAML as explicit dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,9 @@ requires-python = ">=3.9"
 authors = [
   { name = "songsjun" }
 ]
-dependencies = []
+dependencies = [
+  "PyYAML>=5.4",
+]
 
 [project.scripts]
 github-pm-agent = "github_pm_agent.cli:main"


### PR DESCRIPTION
## Summary
- `workflow_orchestrator.py` does a hard `import yaml` at module level for loading workflow YAML files
- PyYAML was not declared in `pyproject.toml` dependencies, causing `ModuleNotFoundError` on CI

## Test plan
- [ ] CI passes on all Python versions (3.9, 3.12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)