### PR TITLE
fix: address 6 code-review issues in discussion workflow and gate scanner

### DIFF
--- a/prompts/discussion/issue_breakdown.md
+++ b/prompts/discussion/issue_breakdown.md
@@ -8,6 +8,7 @@ $artifact_requirements
 **Final Technical Design:**
 $artifact_final_design
 
+$human_comment
 $pending_comments
 ---
 

--- a/prompts/discussion/tech_proposal.md
+++ b/prompts/discussion/tech_proposal.md
@@ -5,6 +5,7 @@ You are a senior software engineer writing a technical design proposal.
 **Product Requirements:**
 $artifact_requirements
 
+$human_comment
 $pending_comments
 ---
 

--- a/src/github_pm_agent/phase_gate_scanner.py
+++ b/src/github_pm_agent/phase_gate_scanner.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from github_pm_agent.utils import append_jsonl, read_jsonl, utc_now_iso
 from github_pm_agent.workflow_instance import WorkflowInstance
@@ -15,11 +15,11 @@ class PhaseGateScanner:
         self.owner_login = owner_login
         self.advanced_path = queue.runtime_dir / "gate_advanced.jsonl"
 
-    def _already_advanced(self) -> set:
+    def _already_advanced(self) -> Set[Tuple[str, int]]:
         return {
-            item["gate_issue_number"]
+            (item["repo"], item["gate_issue_number"])
             for item in read_jsonl(self.advanced_path)
-            if item.get("gate_issue_number") is not None
+            if item.get("repo") and item.get("gate_issue_number") is not None
         }
 
     def scan_and_advance(self) -> List[Dict[str, Any]]:
@@ -46,7 +46,7 @@ class PhaseGateScanner:
             if instance.is_terminated() or instance.is_completed():
                 continue
             gate_issue_number = instance.get_gate_issue_number()
-            if gate_issue_number is None or gate_issue_number in already_advanced:
+            if gate_issue_number is None or (repo, gate_issue_number) in already_advanced:
                 continue
 
             human_comment = self._check_gate_resolved(gate_issue_number, repo)

--- a/src/github_pm_agent/poller.py
+++ b/src/github_pm_agent/poller.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import re
+import subprocess
 from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional
 
@@ -80,8 +81,9 @@ class GitHubPoller:
         events.extend(self._poll_repo_events(since_iso))
         try:
             events.extend(self._poll_projects(since_iso))
-        except Exception:  # noqa: BLE001
-            pass  # read:project scope may not be available
+        except subprocess.CalledProcessError as exc:
+            if not self._is_project_scope_error(exc):
+                raise
         events.extend(self._poll_milestones(since_iso))
         events.extend(self._poll_issues(since_iso))
         events.extend(self._poll_issue_events(since_iso))
@@ -102,6 +104,22 @@ class GitHubPoller:
             unique_events.values(),
             key=lambda item: (parse_iso8601(item.occurred_at), item.event_id),
         )
+
+    @staticmethod
+    def _is_project_scope_error(exc: subprocess.CalledProcessError) -> bool:
+        stderr = " ".join(
+            part.strip()
+            for part in (exc.stderr, exc.output)
+            if isinstance(part, str) and part.strip()
+        ).lower()
+        if not stderr:
+            return False
+        if any(
+            token in stderr
+            for token in ("insufficient_scopes", "insufficient scopes", "missing required scope", "read:project")
+        ):
+            return True
+        return "scope" in stderr and "project" in stderr
 
     def _poll_notifications(self, since_iso: str) -> List[Event]:
         since_dt = parse_iso8601(since_iso)

--- a/src/github_pm_agent/workflow_orchestrator.py
+++ b/src/github_pm_agent/workflow_orchestrator.py
@@ -249,8 +249,8 @@ class WorkflowOrchestrator:
             for phase_name, artifact_text in artifacts.items():
                 if not phase_name.startswith("_"):
                     variables[f"artifact_{phase_name}"] = artifact_text
-            gate_comment = meta.get("gate_human_comment", "")
-            variables["human_comment"] = f"Human feedback:\n{gate_comment}\n" if gate_comment else ""
+            human_comment = meta.get("gate_human_comment", "")
+            variables["human_comment"] = f"Human feedback:\n{human_comment}\n" if human_comment else ""
             pending = instance.get_pending_comments()
             variables["pending_comments"] = "\n\n---\n\n".join(pending) if pending else ""
 
@@ -282,8 +282,47 @@ class WorkflowOrchestrator:
                 for ai_out in [o for o in all_ai_outputs if o["phase"] == current_phase]:
                     instance.set_artifact(f"{current_phase}_{ai_out['role']}", ai_out["content"])
 
-            if pending:
-                instance.clear_pending_comments()
+            step_succeeded = False
+
+            # Actions must run before gate creation so gates can reflect the action result.
+            if step.get("action") == "create_issues":
+                created_issues, issue_creation_error = self._create_issues_from_artifact(last_content, event)
+                issue_refs = []
+                for item in created_issues:
+                    number = (item.get("result") or {}).get("number") or item.get("number")
+                    title = item.get("title", "")
+                    issue_refs.append({"number": number, "title": title})
+                if issue_refs:
+                    instance.set_created_issue_refs(issue_refs)
+                if issue_creation_error:
+                    break
+                step_succeeded = True
+            elif step.get("action") == "evaluate_design":
+                eval_result = self._evaluate_design(last_content, event, instance, steps, current_phase)
+                if eval_result.get("terminated"):
+                    return {
+                        "phase": current_phase,
+                        "ai_outputs": all_ai_outputs,
+                        "gate": {},
+                        "artifacts": instance.get_artifacts(),
+                        "created_issues": [],
+                        "issue_creation_error": "",
+                        "terminated": True,
+                        "terminated_reason": eval_result.get("reason", ""),
+                        "escalation_refs": [],
+                    }
+                if eval_result.get("escalated"):
+                    gate_result = eval_result.get("gate", {})
+                    if pending:
+                        instance.clear_pending_comments()
+                    break
+                if eval_result.get("error"):
+                    issue_creation_error = eval_result["error"]
+                    # Don't advance on error — break without set_completed to allow retry
+                    break
+                step_succeeded = True
+            else:
+                step_succeeded = True
 
             if step.get("gate"):
                 idx = next((i for i, s in enumerate(steps) if s.get("phase") == current_phase), -1)
@@ -305,39 +344,12 @@ class WorkflowOrchestrator:
                 if gate_number and next_phase:
                     instance.set_gate(gate_number, next_phase)
                 gate_result = {"gate_issue_number": gate_number, "next_phase": next_phase}
+                if pending:
+                    instance.clear_pending_comments()
                 break  # wait for human
 
-            # Non-gate step: handle action
-            if step.get("action") == "create_issues":
-                created_issues, issue_creation_error = self._create_issues_from_artifact(last_content, event)
-                issue_refs = []
-                for item in created_issues:
-                    number = (item.get("result") or {}).get("number") or item.get("number")
-                    title = item.get("title", "")
-                    issue_refs.append({"number": number, "title": title})
-                if issue_refs:
-                    instance.set_created_issue_refs(issue_refs)
-            elif step.get("action") == "evaluate_design":
-                eval_result = self._evaluate_design(last_content, event, instance, steps, current_phase)
-                if eval_result.get("terminated"):
-                    return {
-                        "phase": current_phase,
-                        "ai_outputs": all_ai_outputs,
-                        "gate": {},
-                        "artifacts": instance.get_artifacts(),
-                        "created_issues": [],
-                        "issue_creation_error": "",
-                        "terminated": True,
-                        "terminated_reason": eval_result.get("reason", ""),
-                        "escalation_refs": [],
-                    }
-                if eval_result.get("escalated"):
-                    gate_result = eval_result.get("gate", {})
-                    break
-                if eval_result.get("error"):
-                    issue_creation_error = eval_result["error"]
-                    # Don't advance on error — break without set_completed to allow retry
-                    break
+            if pending and step_succeeded:
+                instance.clear_pending_comments()
 
             idx = next((i for i, s in enumerate(steps) if s.get("phase") == current_phase), -1)
             next_step = steps[idx + 1] if 0 <= idx < len(steps) - 1 else None

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -1,4 +1,5 @@
 import unittest
+import subprocess
 
 from github_pm_agent.poller import GitHubPoller
 
@@ -109,6 +110,77 @@ class GitHubPollerTest(unittest.TestCase):
         self.assertEqual(mention_events[0].target_kind, "pull_request")
         self.assertEqual([event.event_type for event in project_events], ["project_changed"])
         self.assertEqual([event.event_type for event in milestone_events], ["milestone_changed"])
+
+    def test_poll_ignores_project_scope_errors(self) -> None:
+        since = "2026-03-19T10:00:00Z"
+
+        class ProjectScopeErrorClient(FakeClient):
+            def iter_graphql_nodes(
+                self,
+                query,
+                variables=None,
+                *,
+                connection_path,
+                cursor_variable,
+                page_size_variable,
+                page_size,
+                reverse=False,
+            ):
+                if tuple(connection_path) == ("data", "repository", "projectsV2"):
+                    raise subprocess.CalledProcessError(
+                        1,
+                        ["gh", "api", "graphql"],
+                        stderr="GraphQL: INSUFFICIENT_SCOPES: requires read:project",
+                    )
+                return super().iter_graphql_nodes(
+                    query,
+                    variables,
+                    connection_path=connection_path,
+                    cursor_variable=cursor_variable,
+                    page_size_variable=page_size_variable,
+                    page_size=page_size,
+                    reverse=reverse,
+                )
+
+        poller = GitHubPoller(ProjectScopeErrorClient(), "acme/widgets", "main", [])
+
+        self.assertEqual(poller.poll(since), [])
+
+    def test_poll_reraises_non_scope_project_errors(self) -> None:
+        since = "2026-03-19T10:00:00Z"
+
+        class ProjectFailureClient(FakeClient):
+            def iter_graphql_nodes(
+                self,
+                query,
+                variables=None,
+                *,
+                connection_path,
+                cursor_variable,
+                page_size_variable,
+                page_size,
+                reverse=False,
+            ):
+                if tuple(connection_path) == ("data", "repository", "projectsV2"):
+                    raise subprocess.CalledProcessError(
+                        1,
+                        ["gh", "api", "graphql"],
+                        stderr="GraphQL: something else went wrong",
+                    )
+                return super().iter_graphql_nodes(
+                    query,
+                    variables,
+                    connection_path=connection_path,
+                    cursor_variable=cursor_variable,
+                    page_size_variable=page_size_variable,
+                    page_size=page_size,
+                    reverse=reverse,
+                )
+
+        poller = GitHubPoller(ProjectFailureClient(), "acme/widgets", "main", [])
+
+        with self.assertRaises(subprocess.CalledProcessError):
+            poller.poll(since)
 
     def test_repo_events_capture_push_branch_and_release_signals(self) -> None:
         since = "2026-03-19T10:00:00Z"

--- a/tests/test_workflow_orchestrator.py
+++ b/tests/test_workflow_orchestrator.py
@@ -49,6 +49,18 @@ class RecordingActions:
         return payload
 
 
+class NumberedRecordingActions(RecordingActions):
+    def __init__(self) -> None:
+        super().__init__()
+        self._next_issue_number = 100
+
+    def create_issue(self, title: str, body: str, labels: Optional[List[str]] = None) -> Dict[str, Any]:
+        payload = super().create_issue(title, body, labels)
+        payload["number"] = self._next_issue_number
+        self._next_issue_number += 1
+        return payload
+
+
 class FakeEngine:
     def __init__(self, actions: Any, runtime_dir: Optional[Path] = None) -> None:
         self.actions = actions
@@ -220,50 +232,54 @@ def _discussion_event(**metadata: Any) -> Event:
     )
 
 
-def test_phase_workflow_auto_chains_to_issue_breakdown() -> None:
-    """After requirements completes (no gate), orchestrator auto-chains to issue_breakdown and creates issues."""
+def test_phase_workflow_stops_at_tech_review_gate_after_design_evaluation() -> None:
+    """After tech_proposal completes, tech_review must evaluate first, then open a gate to issue_breakdown."""
     with tempfile.TemporaryDirectory() as tmpdir:
         runtime_dir = Path(tmpdir)
 
-        # Pre-create instance at requirements phase (gate already cleared by prior advance)
+        # Pre-create instance at tech_proposal phase after the prior gate has already advanced.
         instance = WorkflowInstance.load(runtime_dir, "songsjun/example", 5)
-        instance.set_phase("requirements")
+        instance.set_phase("tech_proposal")
+        instance.set_artifact("requirements", "some requirements text")
+        instance.add_pending_comment("Please include background jobs.")
 
         issue_json = '[{"title": "Task 1", "body": "desc", "labels": ["enhancement"]}]'
         tech_review_json = '{"decision": "proceed", "docker_compatible": true, "final_design": "use FastAPI", "evaluation_summary": "good", "problem_coverage": []}'
 
         class FakeEngineWithIssueBreakdown(FakeEngine):
             def run_raw_text_handler(self, event: Any, prompt_path: str, role: str = "pm", variables: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-                self.run_raw_text_handler_calls.append({"event_id": event.event_id, "prompt_path": prompt_path, "role": role})
+                self.run_raw_text_handler_calls.append(
+                    {"event_id": event.event_id, "prompt_path": prompt_path, "role": role, "variables": dict(variables or {})}
+                )
                 if "issue_breakdown" in prompt_path:
                     return {"raw_text": issue_json}
                 if "tech_review" in prompt_path:
                     return {"raw_text": tech_review_json}
                 return {"raw_text": f"output for {role}"}
 
-        actions = RecordingActions()
+        actions = NumberedRecordingActions()
         engine = FakeEngineWithIssueBreakdown(actions, runtime_dir=runtime_dir)
         orchestrator = WorkflowOrchestrator(_project_root(), engine, actions, FakeClient({}), {})
 
         result = orchestrator.process(_discussion_event())
 
-        # AI calls: requirements + issue_breakdown + tech_proposal + tech_review
         phases_called = [c["prompt_path"] for c in engine.run_raw_text_handler_calls]
-        assert any("requirements" in p for p in phases_called)
-        assert any("issue_breakdown" in p for p in phases_called)
         assert any("tech_proposal" in p for p in phases_called)
         assert any("tech_review" in p for p in phases_called)
+        assert not any("issue_breakdown" in p for p in phases_called)
 
-        # One create_issue call for the parsed issue (no gate issue created)
-        assert actions.create_issue_calls[0]["title"] == "Task 1"
-
-        # Result should have created_issues with 1 item
-        assert len(result.get("created_issues", [])) == 1
+        assert len(actions.create_issue_calls) == 1
+        assert actions.create_issue_calls[0]["title"] == "[workflow-gate] songsjun/example Discussion #5 phase=tech_review"
+        assert result.get("gate") == {"gate_issue_number": 100, "next_phase": "issue_breakdown"}
+        assert result.get("created_issues", []) == []
         assert result.get("issue_creation_error", "") == ""
 
-        # Instance should be marked completed
         final_instance = WorkflowInstance.load(runtime_dir, "songsjun/example", 5)
-        assert final_instance.is_completed() is True
+        assert final_instance.get_artifacts().get("final_design") == "use FastAPI"
+        assert final_instance.get_gate_issue_number() == 100
+        assert final_instance.get_gate_next_phase() == "issue_breakdown"
+        assert final_instance.get_pending_comments() == []
+        assert final_instance.is_completed() is False
 
 
 def test_phase_workflow_skips_when_completed() -> None:
@@ -289,7 +305,7 @@ def test_phase_workflow_skips_when_completed() -> None:
 
 
 def test_create_issues_from_artifact_fails_loudly_on_bad_json() -> None:
-    """When issue_breakdown returns non-JSON, issue_creation_error is set and no issues are created."""
+    """When issue_breakdown returns non-JSON, the workflow must stay retryable and keep pending comments."""
     with tempfile.TemporaryDirectory() as tmpdir:
         runtime_dir = Path(tmpdir)
 
@@ -297,6 +313,8 @@ def test_create_issues_from_artifact_fails_loudly_on_bad_json() -> None:
         instance = WorkflowInstance.load(runtime_dir, "songsjun/example", 5)
         instance.set_phase("issue_breakdown")
         instance.set_artifact("requirements", "some requirements text")
+        instance.set_artifact("final_design", "some final design text")
+        instance.add_pending_comment("Keep this comment until the step succeeds.")
 
         class FakeEngineBadJson(FakeEngine):
             def run_raw_text_handler(self, event: Any, prompt_path: str, role: str = "pm", variables: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
@@ -312,6 +330,9 @@ def test_create_issues_from_artifact_fails_loudly_on_bad_json() -> None:
         assert result.get("issue_creation_error", "") != "", "error should be set for bad JSON"
         assert result.get("created_issues", []) == [], "no issues should be created"
         assert actions.create_issue_calls == [], "create_issue must not be called"
+        final_instance = WorkflowInstance.load(runtime_dir, "songsjun/example", 5)
+        assert final_instance.is_completed() is False
+        assert final_instance.get_pending_comments() == ["Keep this comment until the step succeeds."]
 
 
 def test_phase_workflow_skips_when_gate_already_open() -> None:
@@ -472,8 +493,8 @@ def test_evaluate_design_terminates_on_docker_incompatible() -> None:
         assert final_instance.is_terminated() is True
 
 
-def test_evaluate_design_proceeds_and_saves_final_design() -> None:
-    """When tech_review outputs proceed + docker_compatible=true, final_design is saved and workflow completes."""
+def test_evaluate_design_proceeds_and_opens_gate_to_issue_breakdown() -> None:
+    """When tech_review outputs proceed, final_design is saved before opening the next gate."""
     with tempfile.TemporaryDirectory() as tmpdir:
         runtime_dir = Path(tmpdir)
 
@@ -494,16 +515,77 @@ def test_evaluate_design_proceeds_and_saves_final_design() -> None:
                     return {"raw_text": proceed_json}
                 return {"raw_text": f"output for {role}"}
 
-        actions = RecordingActions()
+        actions = NumberedRecordingActions()
         engine = FakeEngineProceed(actions, runtime_dir=runtime_dir)
         orchestrator = WorkflowOrchestrator(_project_root(), engine, actions, FakeClient({}), {})
 
         result = orchestrator.process(_discussion_event())
 
         assert not result.get("terminated")
+        assert result.get("gate") == {"gate_issue_number": 100, "next_phase": "issue_breakdown"}
         final_instance = WorkflowInstance.load(runtime_dir, "songsjun/example", 5)
         assert final_instance.get_artifacts().get("final_design") == "use FastAPI"
-        assert final_instance.is_completed() is True
+        assert final_instance.get_gate_issue_number() == 100
+        assert final_instance.is_completed() is False
+
+
+def test_gate_human_comment_is_passed_to_resumed_prompt_variables() -> None:
+    """Gate resolution comments must be available to resumed tech_proposal and issue_breakdown prompts."""
+    cases = [
+        (
+            "tech_proposal",
+            {"requirements": "some requirements text"},
+            "prompts/discussion/tech_proposal.md",
+            "output for engineer",
+        ),
+        (
+            "issue_breakdown",
+            {"requirements": "some requirements text", "final_design": "use FastAPI"},
+            "prompts/discussion/issue_breakdown.md",
+            '[{"title": "Task 1", "body": "desc", "labels": ["enhancement"]}]',
+        ),
+    ]
+
+    for phase, artifacts, expected_prompt, raw_text in cases:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runtime_dir = Path(tmpdir)
+            instance = WorkflowInstance.load(runtime_dir, "songsjun/example", 5)
+            instance.set_phase(phase)
+            for name, value in artifacts.items():
+                instance.set_artifact(name, value)
+
+            class FakeEngineCaptureVariables(FakeEngine):
+                def run_raw_text_handler(
+                    self,
+                    event: Any,
+                    prompt_path: str,
+                    role: str = "pm",
+                    variables: Optional[Dict[str, Any]] = None,
+                ) -> Dict[str, Any]:
+                    self.run_raw_text_handler_calls.append(
+                        {
+                            "event_id": event.event_id,
+                            "prompt_path": prompt_path,
+                            "role": role,
+                            "variables": dict(variables or {}),
+                        }
+                    )
+                    return {"raw_text": raw_text}
+
+            actions = RecordingActions()
+            engine = FakeEngineCaptureVariables(actions, runtime_dir=runtime_dir)
+            orchestrator = WorkflowOrchestrator(_project_root(), engine, actions, FakeClient({}), {})
+
+            orchestrator.process(_discussion_event(gate_human_comment="Prefer Postgres"))
+
+            first_call = engine.run_raw_text_handler_calls[0]
+            assert expected_prompt in first_call["prompt_path"]
+            assert first_call["variables"]["human_comment"] == "Human feedback:\nPrefer Postgres\n"
+
+
+def test_gate_human_comment_placeholders_exist_in_resumed_prompts() -> None:
+    assert "$human_comment" in (_project_root() / "prompts/discussion/tech_proposal.md").read_text(encoding="utf-8")
+    assert "$human_comment" in (_project_root() / "prompts/discussion/issue_breakdown.md").read_text(encoding="utf-8")
 
 
 def test_phase_gate_scanner_skips_terminated_instance() -> None:
@@ -548,3 +630,70 @@ def test_phase_gate_scanner_skips_terminated_instance() -> None:
 
         assert advanced == [], "terminated instance must not be re-queued"
         assert store.pop() is None, "nothing should have been enqueued"
+
+
+def test_phase_gate_scanner_deduplicates_by_repo_and_issue_number() -> None:
+    """Advancement records for another repo must not block the same gate number in this repo."""
+    from github_pm_agent.phase_gate_scanner import PhaseGateScanner
+    from github_pm_agent.queue_store import QueueStore
+    from github_pm_agent.utils import append_jsonl
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        runtime_dir = Path(tmpdir)
+        store = QueueStore(runtime_dir)
+
+        append_jsonl(
+            runtime_dir / "gate_advanced.jsonl",
+            {
+                "gate_issue_number": 99,
+                "repo": "otherorg/example",
+                "discussion_number": 1,
+                "from_phase": "tech_review",
+                "to_phase": "issue_breakdown",
+                "advanced_at": "2026-03-20T00:00:00Z",
+            },
+        )
+
+        instance = WorkflowInstance.load(runtime_dir, "songsjun/example", 5)
+        instance.set_phase("tech_review")
+        instance.set_gate(99, "issue_breakdown")
+        instance.set_original_event(
+            {
+                "event_id": "evt-disc-1",
+                "event_type": "discussion",
+                "source": "test",
+                "occurred_at": "2026-03-20T00:00:00Z",
+                "repo": "songsjun/example",
+                "actor": "alice",
+                "url": "https://example.test/discussions/5",
+                "title": "Feature idea",
+                "body": "Let's brainstorm",
+                "target_kind": "discussion",
+                "target_number": 5,
+                "metadata": {},
+            }
+        )
+
+        class FakeClientClosed:
+            def api(self, path: str, params: Any = None, method: str = "GET") -> Any:
+                if "/comments" in path:
+                    return []
+                if path == "repos/songsjun/example/issues/99":
+                    return {"state": "closed"}
+                return []
+
+        scanner = PhaseGateScanner(store, FakeClientClosed(), "")
+        advanced = scanner.scan_and_advance()
+
+        assert advanced == [
+            {
+                "repo": "songsjun/example",
+                "discussion_number": 5,
+                "from_phase": "tech_review",
+                "to_phase": "issue_breakdown",
+            }
+        ]
+        resumed = store.pop()
+        assert resumed is not None
+        assert resumed.metadata["advance_to_phase"] == "issue_breakdown"
+        assert resumed.metadata["gate_human_comment"] == ""


### PR DESCRIPTION
## Summary

Found via Codex review, fixed and verified (119 tests pass):

1. **(High)** `tech_review` gate ran before `evaluate_design` — `final_design` was never stored, docker_compatible check was skipped. Fixed by running actions before gate creation.
2. **(Medium)** `issue_breakdown` failure still marked workflow complete. Fixed with early `break` on `issue_creation_error`.
3. **(Medium)** `PhaseGateScanner` deduped by issue number only — cross-repo false positives. Fixed with `(repo, issue_number)` tuple key.
4. **(Medium)** Gate owner comments dropped before next phase prompt. Fixed by propagating `gate_human_comment` as `$human_comment` into `tech_proposal.md` and `issue_breakdown.md`.
5. **(Medium)** `pending_comments` cleared before step success confirmed. Fixed: only clear after full step success; errors preserve comments for retry.
6. **(Medium)** Bare `except Exception` in `_poll_projects` masked real failures. Fixed: narrow to `subprocess.CalledProcessError` with scope-error check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)